### PR TITLE
Different Swagger_File and Endpoint URLs for ingestion of OpenAPI

### DIFF
--- a/metadata-ingestion/openapitest.yml
+++ b/metadata-ingestion/openapitest.yml
@@ -1,0 +1,10 @@
+sink:
+  type: datahub-rest
+  config:
+    server: "http://localhost:8080"
+source:
+  type: openapi
+  config:
+    name: "My OpenAPI Source"
+    swagger_file: "http://integrationszone-mock-api.s3-website.eu-north-1.amazonaws.com/books_openapi.json"
+    url: "https://ot11l24sdi.execute-api.eu-north-1.amazonaws.com"

--- a/metadata-ingestion/src/datahub/ingestion/source/openapi.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/openapi.py
@@ -50,7 +50,7 @@ class OpenApiConfig(ConfigModel):
     name: str = Field(description="Name of ingestion.")
     url: str = Field(description="Endpoint URL. e.g. https://example.com")
     swagger_file: str = Field(
-        description="Route for access to the swagger file. e.g. openapi.json"
+        description="URL for accessing the swagger file. e.g. https://example.com/openapi.json, alternatively a path like openapi.json, then it takes the url above as default + the specified path"
     )
     ignore_endpoints: list = Field(
         default=[], description="List of endpoints to ignore during ingestion."

--- a/metadata-ingestion/src/datahub/ingestion/source/openapi_parser.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/openapi_parser.py
@@ -71,9 +71,10 @@ def get_swag_json(
     username: Optional[str] = None,
     password: Optional[str] = None,
     swagger_file: str = "",
+    password: Optional[str] = None,
     proxies: Optional[dict] = None,
 ) -> Dict:
-    tot_url = url + swagger_file
+    tot_url = swagger_file
     response = request_call(
         url=tot_url, token=token, username=username, password=password, proxies=proxies
     )

--- a/metadata-ingestion/src/datahub/ingestion/source/openapi_parser.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/openapi_parser.py
@@ -71,7 +71,6 @@ def get_swag_json(
     username: Optional[str] = None,
     password: Optional[str] = None,
     swagger_file: str = "",
-    password: Optional[str] = None,
     proxies: Optional[dict] = None,
 ) -> Dict:
     tot_url = swagger_file


### PR DESCRIPTION
Fix for #168 Pfad in DataHub Code anpassen damit URL Und Swagger URL nicht gleich sein müssen

Das Problem ist dass bei der DataHub Open API Ingestion zusätzlich eine Swagger-Datei (OpenAPI Spec) erwartet wird, bei der nur ein Pfad (keine URL) eingegeben werden kann. D.h. DataHub erwartet, dass die OpenAPI Spec auf dem gleichen Endpunkt liegt wie der eig. REST-Endpunkt.

Lösung:
Es wird Custom Code benötigt um die OpenAPI Ingestion anzupassen, sodass URL und swagger_file unterschiedliche URLs haben können .
https://datahubspace.slack.com/archives/CUMUWQU66/p1717405048211779